### PR TITLE
Adds Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ logs
 sandbox
 config.json
 *.swp
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM jjmerelo/alpine-perl6:latest
+LABEL version="1.0" maintainer="Perl6"
+
+RUN mkdir /app
+WORKDIR /app
+
+ADD . /app
+RUN git submodule update --init --recursive
+RUN apk add --update --no-cache zstd libssl1.0 build-base
+RUN ln -s /lib/libssl.so.1.0.0 /lib/libssl.so \
+    && ln -s /usr/lib/libssl.so.1.0.0 /usr/lib/libssl.so
+
+RUN zef install --force --deps-only . && rakudobrew rehash
+    
+
+FROM andyceo/lrzip as lrzip
+COPY --from=lrzip /usr/local/bin/lrzip /usr/local/bin/lrzip


### PR DESCRIPTION
This is a base dockerfile which includes all bots, all source, all
dependencies. It's got no entrypoint defined, so you can run anything
included in the `bin` subdirectory.

It's not tested extensively, but it's there. So it closes #323.

Also :see_no_evil: adding emacs backup files to .gitignore