### PR TITLE
Remove useless `:bin` argument from call to spurt

### DIFF
--- a/lib/Whateverable/Builds.pm6
+++ b/lib/Whateverable/Builds.pm6
@@ -109,7 +109,7 @@ sub fetch-build($full-commit-hash, :$backend!) is export {
 
     my $location = $CONFIG<archives-location>.IO.add: $backend;
     my $archive  = $location.add: ~$0;
-    spurt $archive, $response.content, :bin;
+    spurt $archive, $response.content;
 
     if $archive.ends-with: ‘.lrz’ { # populate symlinks
         my $proc = run :out, :bin, <lrzip -dqo - -->, $archive;


### PR DESCRIPTION
Otherwise with recently built blin image I am getting this:

```
🥞 Testing start and end points
Attempting to fetch ee96b37ad31cc8a4e712f623133625466eb9700f…
Unexpected named argument 'bin' passed
  in sub fetch-build at /opt/rakudo-pkg/share/perl6/site/sources/9C6193D640C25EF0434B1DF45A2171DB9CD11401 (Whateverable::Builds) line 112
  in sub build-exists at /opt/rakudo-pkg/share/perl6/site/sources/9C6193D640C25EF0434B1DF45A2171DB9CD11401 (Whateverable::Builds) line 143
  in sub MAIN at bin/blin.p6 line 164
  in block <unit> at bin/blin.p6 line 12
```