### PR TITLE
Switch the IRC host to libera

### DIFF
--- a/lib/Whateverable.pm6
+++ b/lib/Whateverable.pm6
@@ -214,7 +214,7 @@ method selfrun($nick is copy, @alias?) {
         :password(?%*ENV<TESTABLE> ?? ‘’ !! $CONFIG<irc><login password>.join: ‘:’)
         :@alias
         # IPv4 address of chat.freenode.net is hardcoded so that we can double the limit ↓
-        :host(%*ENV<TESTABLE> ?? ‘127.0.0.1’ !! <chat.freenode.net 195.154.200.232>.pick)
+        :host(%*ENV<TESTABLE> ?? ‘127.0.0.1’ !! <irc.libera.chat 130.185.232.126>.pick)
         :port(%*ENV<TESTABLE> ?? %*ENV<TESTABLE_PORT> !! 6667)
         :channels(%*ENV<DEBUGGABLE>
                   ?? $CONFIG<cave>


### PR DESCRIPTION
Because freenode is no longer a thing (and everything moved to libera).
Note that this tweak was hastily applied on the server and remained
uncommitted, so actually this commit changes nothing, it's just about
committing what is already there.

The IP address in this commit is what I got when pinging
`irc.libera.chat`, it's needed to work around the issue of having too
many bots per IP (connecting to an IPv4 address forcefully uses IPv4
address, which is treated like a completely different connection and
thus has its own limit). It's a very old hack that for now has to
remain, I think. And yes, that IP can change over time, but until there
is a better fix I'm not sure if anything can be done about it.