### PR TITLE
Fix FootgunDB to write into a temp file first

### DIFF
--- a/lib/Whateverable/FootgunDB.pm6
+++ b/lib/Whateverable/FootgunDB.pm6
@@ -31,8 +31,12 @@ method clean {
     $!db.unlink if %*ENV<TESTABLE>
 }
 
-method read()       { from-json slurp $!db                              }
-method write(%data) {           spurt $!db, to-json :sorted-keys, %data }
+method read() {
+    from-json slurp $!db
+}
+method write(%data) {
+    spurt $!db, to-json :sorted-keys, %data
+}
 method read-write(&code) {
     $!lock.protect: {
         my %data := self.read;


### PR DESCRIPTION
The comment in the code should explain everything. Without this the bots can trash their own files when the system runs out of space.