### PR TITLE
Improve Tellable's .seen normalization on startup

### DIFF
--- a/xbin/Tellable.p6
+++ b/xbin/Tellable.p6
@@ -181,9 +181,14 @@ multi method irc-to-me($msg where { m:r/^ \s* [[to|tell|ask] \s+]? $<text>=[
     $db-tell.write:   $db-tell.read.values».list.flat.classify: {
         normalize-weirdly .<to>
     };
-    $db-seen.write: %($db-seen.read.values.map: {
-        normalize-weirdly(.<nick>) => $_
-    });
+    my %seens = %();
+    for $db-seen.read.values {
+        my $normalized = normalize-weirdly .<nick>;
+        if %seens{$normalized}:!exists or DateTime.new(%seens{$normalized}<timestamp>) < DateTime.new(.<timestamp>) {
+            %seens{$normalized} = $_;
+        }
+    }
+    $db-seen.write: %seens;
 }
 
 Tellable.new.selfrun: ‘tellable6’, [/ [to|tell|ask|seen] 6? <before ‘:’> /,


### PR DESCRIPTION
Tellable stores a dict of all latest messages by all users that it has
seen. However, the keys in that dict are not exact nicknames. Instead,
they are intentionally mangled simplified versions of nicknames. The
goal of the normalization is to allow users to change their nicknames
slightly and still receive messages, and have `.seen` that DWIMs.
AlexDaniel, AlexDaniel11, alexdaniel_, etc. are all treated the same by
Tellable, that's what makes this bot so nice. 😌

Now, when the bot starts up, it could be that the file was created with
old rules, or the file was recovered from something that didn't follow
the same rules. For that reason the code renormalizes the entire seen
and tell files and saves them back. However, now that I looked at the
code again, I realized that there is a flaw. If two nicknames get
normalized to the same value, it should pick the latest message and
discard the old one. However, the code was just keeping one random
message instead of taking the timestamp into account. This commit fixes
that.